### PR TITLE
Lock version of `insta`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test-latest:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["snapshot", "cmd", "trycmd", "assert-cmd"]
 readme = "README.md"
 
 [dependencies]
-insta = { version = "1.17.0" }
+insta = { version = "~1.17.0" }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.82"

--- a/src/bin/hello.rs
+++ b/src/bin/hello.rs
@@ -2,6 +2,7 @@ fn main() {
     println!("Hello Bin!");
 }
 
+/// Requires running `cargo build` before running this test.
 #[test]
 fn test_cli() {
     use insta_cmd::{assert_cmd_snapshot, get_cargo_bin, Command};


### PR DESCRIPTION
On a more recent version of insta, the build fails