### PR TITLE
Sort env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+/target*
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,15 @@ fn test_command() {
 }
 
 #[test]
+fn test_env() {
+    assert_cmd_snapshot!(Command::new("echo")
+        .arg("Just some stuff")
+        .env("K", "V")
+        .env("A", "B")
+        .env("Y", "Z"));
+}
+
+#[test]
 #[allow(deprecated)]
 fn test_stdin() {
     assert_cmd_snapshot!(StdinCommand::new("cat", "Hello World!"));

--- a/src/snapshots/insta_cmd__env.snap
+++ b/src/snapshots/insta_cmd__env.snap
@@ -1,0 +1,17 @@
+---
+source: src/lib.rs
+info:
+  program: echo
+  args:
+    - Just some stuff
+  env:
+    A: B
+    K: V
+    Y: Z
+---
+success: true
+exit_code: 0
+----- stdout -----
+Just some stuff
+
+----- stderr -----

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsStr;
 use std::io::Write;
@@ -7,29 +7,16 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Info {
     program: String,
     args: Vec<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde(serialize_with = "ordered_map")]
-    env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    env: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stdin: Option<String>,
-}
-
-/// For use with serde's [serialize_with] attribute
-fn ordered_map<S, K: Ord + Serialize, V: Serialize>(
-    value: &HashMap<K, V>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let ordered: BTreeMap<_, _> = value.iter().collect();
-    ordered.serialize(serializer)
 }
 
 fn describe_program(cmd: &OsStr) -> String {

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::ffi::OsStr;
 use std::io::Write;
@@ -7,16 +7,29 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 #[derive(Serialize)]
 pub struct Info {
     program: String,
     args: Vec<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "ordered_map")]
     env: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stdin: Option<String>,
+}
+
+/// For use with serde's [serialize_with] attribute
+fn ordered_map<S, K: Ord + Serialize, V: Serialize>(
+    value: &HashMap<K, V>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let ordered: BTreeMap<_, _> = value.iter().collect();
+    ordered.serialize(serializer)
 }
 
 fn describe_program(cmd: &OsStr) -> String {


### PR DESCRIPTION
Similar to `sort_maps` in insta, but happens by default. I don't think there's a good reason not to sort them...
