### PR TITLE
Release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "insta-cmd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "insta-cmd"
 readme = "README.md"
 repository = "https://github.com/mitsuhiko/insta-cmd"
 rust-version = "1.68.0"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 # Cargo.lock is committed to ensure MSRV compatibility.


### PR DESCRIPTION
Cut the 0.7.0 release. The last published version, 0.6.0, dates to April 2024; `main` has since gained the `env_remove`-vs-empty snapshot fix (#20), an MSRV bump from 1.57 to 1.68, and a committed `Cargo.lock`. This PR only bumps the version — the substantive changes are already on `main`.

I've made this a minor (not patch) bump because both the MSRV raise and the snapshot-output change are visible to consumers: a variable cleared via `Command::env_remove` is no longer recorded as `KEY: ""` in the snapshot `env:` block (it's now omitted, distinct from a deliberate `.env("KEY", "")`), so downstream snapshots that exercise `env_remove` will shift on regeneration.

`cargo publish --dry-run` and `make test` both pass on this branch.

> _This was written by Claude Code on behalf of max_
